### PR TITLE
Add environment variable for Poppler path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ source venv_tk/bin/activate
 - **Poppler**
   - Windows: скачайте архив на странице [oschwartz10612/poppler-windows](https://github.com/oschwartz10612/poppler-windows/releases) и распакуйте рядом с `final.py` (папка `poppler-24.08.0` уже указана в коде) либо добавьте путь к `bin` в переменную окружения `PATH` и измените переменную `poppler_path` в `final.py`.
   - Linux/MacOS: установите через пакетный менеджер (`apt install poppler-utils` или `brew install poppler`).
+  - Можно также задать путь к Poppler через переменную окружения `POPPLER_PATH`.
 - **Tesseract OCR**
   - Windows: скачайте установщик с [tesseract-ocr/tesseract](https://github.com/tesseract-ocr/tesseract) или установите `choco install tesseract`.
   - Linux/MacOS: `apt install tesseract-ocr` или `brew install tesseract`.

--- a/final.py
+++ b/final.py
@@ -17,6 +17,10 @@ def main():
         "Library",
         "bin",
     )
+    # Если указана переменная окружения POPPLER_PATH, используем её
+    env_poppler = os.getenv("POPPLER_PATH")
+    if env_poppler:
+        poppler_path = env_poppler
 
     # 🔕 Отключаем главное окно tkinter (оно нам не нужно)
     Tk().withdraw()


### PR DESCRIPTION
## Summary
- allow overriding `poppler_path` with `POPPLER_PATH` env variable
- document `POPPLER_PATH` in README

## Testing
- `python -m py_compile final.py`


------
https://chatgpt.com/codex/tasks/task_e_68480d175cf88321865f3d168dcfd6ff