### PR TITLE
Handle Tesseract path via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ source venv_tk/bin/activate
   - Linux/MacOS: установите через пакетный менеджер (`apt install poppler-utils` или `brew install poppler`).
   - Можно также задать путь к Poppler через переменную окружения `POPPLER_PATH`.
 - **Tesseract OCR**
-  - Windows: скачайте установщик с [tesseract-ocr/tesseract](https://github.com/tesseract-ocr/tesseract) или установите `choco install tesseract`.
-  - Linux/MacOS: `apt install tesseract-ocr` или `brew install tesseract`.
-  Если исполняемый файл не находится в `PATH`, пропишите его путь в `pytesseract.pytesseract.tesseract_cmd` внутри `final.py`.
+   - Windows: скачайте установщик с [tesseract-ocr/tesseract](https://github.com/tesseract-ocr/tesseract) или установите `choco install tesseract`.
+   - Linux/MacOS: `apt install tesseract-ocr` или `brew install tesseract`.
+   Если исполняемый файл не находится в `PATH`, пропишите его путь в `pytesseract.pytesseract.tesseract_cmd` внутри `final.py`
+   или задайте переменную окружения `TESSERACT_CMD` с этим путём.
 
 После установки Poppler и Tesseract запустите скрипт ещё раз, чтобы разделить PDF на страницы.

--- a/final.py
+++ b/final.py
@@ -22,6 +22,11 @@ def main():
     if env_poppler:
         poppler_path = env_poppler
 
+    # Если задан путь к Tesseract через TESSERACT_CMD, передаём его pytesseract
+    env_tesseract = os.getenv("TESSERACT_CMD")
+    if env_tesseract:
+        pytesseract.pytesseract.tesseract_cmd = env_tesseract
+
     # 🔕 Отключаем главное окно tkinter (оно нам не нужно)
     Tk().withdraw()
 


### PR DESCRIPTION
## Summary
- allow using `TESSERACT_CMD` to override tesseract path
- document the environment variable in README

## Testing
- `python -m py_compile final.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68480db93a6083219a530ad6d4a1257e