### PR TITLE
Add dependency detection and exit on missing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,11 +67,15 @@ source venv_tk/bin/activate
   - Установите Poppler так, чтобы утилита `pdftoppm` находилась в системной переменной `PATH`. Если она доступна, скрипт определит Poppler автоматически.
   - Windows: скачайте архив на странице [oschwartz10612/poppler-windows](https://github.com/oschwartz10612/poppler-windows/releases), распакуйте его в удобное место и добавьте подкаталог `bin` в `PATH`.
   - Linux/MacOS: установите Poppler через пакетный менеджер (`apt install poppler-utils` или `brew install poppler`).
-  - При необходимости путь к Poppler можно задать вручную через переменную окружения `POPPLER_PATH`.
-- **Tesseract OCR**
+    - При необходимости путь к Poppler можно задать вручную через переменную окружения `POPPLER_PATH`.
+  - **Tesseract OCR**
    - Windows: скачайте установщик с [tesseract-ocr/tesseract](https://github.com/tesseract-ocr/tesseract) или установите `choco install tesseract`.
    - Linux/MacOS: `apt install tesseract-ocr` или `brew install tesseract`.
-   Если исполняемый файл не находится в `PATH`, пропишите его путь в `pytesseract.pytesseract.tesseract_cmd` внутри `final.py`
-   или задайте переменную окружения `TESSERACT_CMD` с этим путём.
+    Если исполняемый файл не находится в `PATH`, пропишите его путь в `pytesseract.pytesseract.tesseract_cmd` внутри `final.py`
+    или задайте переменную окружения `TESSERACT_CMD` с этим путём.
+
+При запуске скрипт проверяет наличие `tesseract` и `pdftoppm` в системном `PATH`.
+Если утилиты не найдены и не заданы переменные `TESSERACT_CMD` и `POPPLER_PATH`,
+выводится предупреждение и работа завершается.
 
 После установки Poppler и Tesseract запустите скрипт ещё раз, чтобы разделить PDF на страницы.

--- a/final.py
+++ b/final.py
@@ -13,6 +13,24 @@ from tqdm import tqdm
 
 def main():
     """Split PDF into separate files using OCR for naming."""
+
+    # 🔍 Проверяем доступность необходимых утилит
+    tesseract_cmd = shutil.which("tesseract")
+    pdftoppm_cmd = shutil.which("pdftoppm")
+    if not tesseract_cmd and not os.getenv("TESSERACT_CMD"):
+        print(
+            "⚠️ Tesseract OCR не найден. Установите Tesseract или задайте "
+            "переменную окружения TESSERACT_CMD."
+        )
+        sys.exit(1)
+
+    if not pdftoppm_cmd and not os.getenv("POPPLER_PATH"):
+        print(
+            "⚠️ Утилита pdftoppm не найдена. Установите Poppler или задайте "
+            "переменную окружения POPPLER_PATH."
+        )
+        sys.exit(1)
+
     parser = argparse.ArgumentParser(
         description="Split PDF into separate files using OCR for naming."
     )
@@ -36,7 +54,7 @@ def main():
     if env_poppler:
         poppler_path = env_poppler
     # Иначе, если в системе есть pdftoppm, используем системный Poppler
-    elif not shutil.which("pdftoppm"):
+    elif not pdftoppm_cmd:
         # Если pdftoppm не найден, берём поставляемый вместе с программой Poppler
         poppler_path = os.path.join(
             os.path.dirname(__file__),


### PR DESCRIPTION
## Summary
- check for `tesseract` and `pdftoppm` at startup
- exit with a warning if either tool isn't found and env vars aren't set
- document dependency checks in README

## Testing
- `python -m py_compile final.py`

------
https://chatgpt.com/codex/tasks/task_e_684856eeef5c8321982ad21a322e929a