### PR TITLE
Fix README snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,6 @@ python final.py --input path/to/file.pdf --output ./pages
 python final.py --input path/to/file.pdf
 ```
 
-
-```bash
-source venv_tk/bin/activate
-```
-
 ## Лицензия
 
 Проект распространяется под лицензией MIT. См. файл [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary
- remove leftover `source venv_tk/bin/activate` command from README

## Testing
- `python final.py --help` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684857ed09408321a5042572e7649bc4