### PR TITLE
Remove unused poppler fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ python final.py --input path/to/file.pdf
   - Windows: скачайте архив на странице [oschwartz10612/poppler-windows](https://github.com/oschwartz10612/poppler-windows/releases), распакуйте его в удобное место и добавьте подкаталог `bin` в `PATH`.
   - Linux/MacOS: установите Poppler через пакетный менеджер (`apt install poppler-utils` или `brew install poppler`).
     - При необходимости путь к Poppler можно задать вручную через переменную окружения `POPPLER_PATH`.
+    - Если вы используете портативную версию Poppler (например, распакованный архив `poppler-24.08.0` рядом со скриптом),
+      укажите путь к каталогу `bin` через `POPPLER_PATH` или добавьте его в `PATH`.
   - **Tesseract OCR**
    - Windows: скачайте установщик с [tesseract-ocr/tesseract](https://github.com/tesseract-ocr/tesseract) или установите `choco install tesseract`.
    - Linux/MacOS: `apt install tesseract-ocr` или `brew install tesseract`.

--- a/final.py
+++ b/final.py
@@ -87,8 +87,8 @@ def main():
     if not pdftoppm_cmd and not os.getenv("POPPLER_PATH"):
         print(
             "⚠️ Утилита pdftoppm не найдена. "
-            "Установите Poppler или задайте "
-            "переменную окружения POPPLER_PATH."
+            "Установите Poppler, добавьте путь к pdftoppm в PATH "
+            "или задайте переменную окружения POPPLER_PATH."
         )
         sys.exit(1)
 
@@ -116,13 +116,7 @@ def main():
         poppler_path = env_poppler
     elif pdftoppm_cmd and not pdftoppm_in_path:
         poppler_path = os.path.dirname(pdftoppm_cmd)
-    elif not pdftoppm_cmd:
-        poppler_path = os.path.join(
-            os.path.dirname(__file__),
-            "poppler-24.08.0",
-            "Library",
-            "bin",
-        )
+    # Попытка использовать локальную копию Poppler больше не предпринимается
 
     # Если задан путь к Tesseract через TESSERACT_CMD, передаём его pytesseract
     env_tesseract = os.getenv("TESSERACT_CMD")


### PR DESCRIPTION
## Summary
- make poppler path check clearer and drop fallback to a missing folder
- mention portable poppler usage in README

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68492b139ebc83218360808fe7fe3e47